### PR TITLE
Actually use defensive static_path_url

### DIFF
--- a/flaskext/lesscss.py
+++ b/flaskext/lesscss.py
@@ -25,9 +25,9 @@ def lesscss(app):
         
         else:
             static_url_path = app.static_url_path
-        
-        static_dir = app.root_path + app.static_url_path
-        
+
+        static_dir = app.root_path + static_url_path
+
         less_paths = []
         for path, subdirs, filenames in os.walk(static_dir):
             less_paths.extend([


### PR DESCRIPTION
The commit you already had defensively checked for whether `app.static_url_path` or `app.static_path` was the right one to use...and then promptly ignore that and went for `app.static_url_path` anyway.  This fixes the behavior to work with (comically old) Flask versions.
